### PR TITLE
Adds Service calls to get county

### DIFF
--- a/src/classes/AddressLookupService.cls
+++ b/src/classes/AddressLookupService.cls
@@ -1,0 +1,45 @@
+public with sharing class AddressLookupService {
+
+	public String coordinateLookupUrl = 'https://geocoding.geo.census.gov/geocoder/locations/address?street={!street}&city={!city}&state={!state}&zip={!zip}&format=json&benchmark=9';
+	public static String countyLookupUrl = 'http://data.fcc.gov/api/block/find?format=json&showall=true&latitude={!latitude}&longitude={!longitude}';
+	public Map<String, String> coordinatesMap;
+
+	public AddressLookupService(Map<String, String> paramMap) {
+		coordinatesMap = new Map<String, String>();
+		for(String key : paramMap.keySet()) coordinateLookupUrl = coordinateLookupUrl.replace('{!'+key+'}', paramMap.get(key));
+	}
+
+	public Map<String, String> getCoordinatesMap() {
+		HttpRequest req = new HttpRequest();
+		req.setMethod('GET');
+		req.setEndpoint(coordinateLookupUrl);
+		Http http = new Http();
+		HTTPResponse res = http.send(req);
+		Map<String, Object> m = (Map<String, Object>)JSON.deserializeUntyped(res.getBody());
+		Map<String, Object> r = (Map<String, Object>)m.get('result');
+		List<Object> addressMatchesList = (List<Object>)r.get('addressMatches');
+		Map<String, Object> a = (Map<String, Object>)addressMatchesList[0];
+		Map<String, Object> c = (Map<String, Object>)a.get('coordinates');
+		coordinatesMap.put('longitude', String.valueOf(c.get('x')));
+		coordinatesMap.put('latitude', String.valueOf(c.get('y')));
+		return coordinatesMap;
+	}
+
+	public String getCountyByCoordinates() {
+		if(coordinatesMap.isEmpty()) getCoordinatesMap();
+		return getCountyByCoordinates(coordinatesMap.get('latitude'), coordinatesMap.get('longitude'));
+	}
+
+	public static String getCountyByCoordinates(String latitude, String longitude) {
+		countyLookupUrl = countyLookupUrl.replace('{!latitude}', latitude);
+		countyLookupUrl = countyLookupUrl.replace('{!longitude}', longitude);
+		HttpRequest req = new HttpRequest();
+		req.setMethod('GET');
+		req.setEndpoint(countyLookupUrl);
+		Http http = new Http();
+		HTTPResponse res = http.send(req);
+		Map<String, Object> m = (Map<String, Object>)JSON.deserializeUntyped(res.getBody());
+		Map<String, Object> r = (Map<String, Object>)m.get('County');
+		return String.valueOf(r.get('name'));
+	}
+}

--- a/src/classes/AddressLookupService.cls-meta.xml
+++ b/src/classes/AddressLookupService.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/classes/AddressLookupServiceTest.cls
+++ b/src/classes/AddressLookupServiceTest.cls
@@ -1,0 +1,52 @@
+@isTest
+public class AddressLookupServiceTest {
+
+	@isTest
+	static void testGetCoordinatesMap() {
+		Test.startTest();
+		Test.setMock(HttpCalloutMock.class, new CensusServiceMock());
+		Map<String, String> paramMap = new Map<String, String>();
+		paramMap.put('street', '3762 Falcon View Drive');
+		paramMap.put('city', 'Arnold');
+		paramMap.put('state', 'MO');
+		paramMap.put('zip', '63010');
+		AddressLookupService svc = new AddressLookupService(paramMap);
+		Map<String, String> coordinatesMap = svc.getCoordinatesMap();
+		System.assert(String.isNotBlank(coordinatesMap.get('latitude')));
+		System.assert(String.isNotBlank(coordinatesMap.get('longitude')));
+		Test.stopTest();
+	}
+
+	@isTest
+	static void testGetCountyByCoordinates() {
+		Test.startTest();
+		Test.setMock(HttpCalloutMock.class, new FccServiceMock());
+		Map<String, String> paramMap = new Map<String, String>();
+		AddressLookupService svc = new AddressLookupService(paramMap);
+		svc.coordinatesMap.put('latitude', '-90.426674');
+		svc.coordinatesMap.put('longitude', '38.448368');
+		String county = svc.getCountyByCoordinates();
+		System.assertEquals('Jefferson', county);
+		Test.stopTest();
+	}
+
+	class CensusServiceMock implements HttpCalloutMock {
+		public HttpResponse respond(HttpRequest req) {
+			HttpResponse res = new HttpResponse();
+	        res.setHeader('Content-Type', 'application/json');
+	        res.setBody('{"result":{"input":{"address":{"state":"MO","street":"3762 Falcon View Drive","zip":"63010","city":"Arnold"},"benchmark":{"id":"9","isDefault":false,"benchmarkName":"Public_AR_Census2010","benchmarkDescription":"Public Address Ranges - Census 2010 Benchmark"}},"addressMatches":[{"matchedAddress":"3762 Falcon View Dr, ARNOLD, MO, 63010","coordinates":{"x":-90.426674,"y":38.448368},"tigerLine":{"side":"R","tigerLineId":"62796419"},"addressComponents":{"state":"MO","zip":"63010","city":"ARNOLD","fromAddress":"3788","toAddress":"3762","preQualifier":"","preDirection":"","preType":"","streetName":"Falcon View","suffixType":"Dr","suffixDirection":"","suffixQualifier":""}}]}}');
+	        res.setStatusCode(200);
+	        return res;
+		}
+	}
+
+	class FccServiceMock implements HttpCalloutMock {
+		public HttpResponse respond(HttpRequest req) {
+			HttpResponse res = new HttpResponse();
+	        res.setHeader('Content-Type', 'application/json');
+	        res.setBody('{"Block":{"FIPS":"290997001192000"},"County":{"FIPS":"29099","name":"Jefferson"},"State":{"FIPS":"29","code":"MO","name":"Missouri"},"status":"OK","executionTime":"192"}');
+	        res.setStatusCode(200);
+	        return res;
+		}
+	}
+}

--- a/src/classes/AddressLookupServiceTest.cls-meta.xml
+++ b/src/classes/AddressLookupServiceTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>34.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Constructs from a Map of address-type values.  Makes a call to
census.gov to obtain the lat/long coordinates from the address values.
Makes call to data.fcc.gov, passing the lat/long coordinates, parsing
the response to return the County.  Adds unit tests.